### PR TITLE
changes to get working crontab example

### DIFF
--- a/esgfpy/update/check_replicas.py
+++ b/esgfpy/update/check_replicas.py
@@ -12,9 +12,9 @@ logging.basicConfig(level=logging.INFO)
 
 # URLs
 # local master Solr that will be checked and updated
-# local_master_solr_url = 'http://localhost:8984/solr'
+local_master_solr_url = 'http://localhost:8984/solr'
 # FIXME
-local_master_solr_url = 'https://localhost:8983/solr'
+#local_master_solr_url = 'http://localhost:8983/solr'
 
 # any ESGF index node used to retrieve the full list
 # of the index nodes in the federation

--- a/scripts/crontab.sh
+++ b/scripts/crontab.sh
@@ -6,7 +6,9 @@
 export CDAT_HOME=/usr/local/conda
 source ${CDAT_HOME}/bin/activate esgf-pub
 
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# SOURCE_DIR is parent dir of the 'scripts' dir containing this script (after resolving any symlink e.g. from cron.weekly)
+script=${BASH_SOURCE[0]}
+SOURCE_DIR=$(python -c "import os.path as P; print P.dirname(P.dirname(P.realpath('$script')))")
 export PYTHONPATH=${SOURCE_DIR}
 
 logfile=/esg/log/check_replicas_cron.log

--- a/scripts/crontab.sh
+++ b/scripts/crontab.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
 # Example script that can be run as a crontab to check local CMIP5 replicas
-# that have changed in the last 5 days
+# that have changed in the last 8 days
+# Symlink into /etc/cron.weekly
 
 export CDAT_HOME=/usr/local/conda
 source ${CDAT_HOME}/bin/activate esgf-pub
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export PYTHONPATH=${SOURCE_DIR}
-python ${SOURCE_DIR}/esgfpy/update/check_replicas.py CMIP5 `date +%Y-%m-%d --date='5 days ago'`
+
+logfile=/esg/log/check_replicas_cron.log
+date >> $logfile
+
+# example with --dry-run
+#python ${SOURCE_DIR}/esgfpy/update/check_replicas.py CMIP5 $(date -d '8 days ago' +%Y-%m-%d) $(date +%Y-%m-%d) --dry-run
+
+python ${SOURCE_DIR}/esgfpy/update/check_replicas.py CMIP5 $(date -d '8 days ago' +%Y-%m-%d) $(date +%Y-%m-%d) >> $logfile 2>&1


### PR DESCRIPTION
1) change to last 8 days instead of 5, so can be put in cron.weekly with a slight overlap

2) change check_replicas.py command line to avoid '--date=' option because it doesn't interact well with optional --dry-run at end of line

3) write output to a log file

4) change logic in SOURCE_DIR (was pointing to the wrong place, also evaluate real path so can symlink into /etc/cron.weekly)

5) Uncomment port 8984 as local solr master. Comment out 8983 (used for slave) but in any case change that line to plain http in case uncommented later.